### PR TITLE
fix refresh cache waiting for all payload syncs

### DIFF
--- a/scripts/refreshCache.ts
+++ b/scripts/refreshCache.ts
@@ -1,6 +1,6 @@
-import {customStorageProvider} from '../src/providers/customStorageProvider';
+﻿import {customStorageProvider} from '../src/providers/customStorageProvider';
 import {refreshCache} from '../src/common/refreshCache';
 import {fileSystemStorageAdapter} from '../src/providers/storage/fileSystem';
 const provider = customStorageProvider(fileSystemStorageAdapter);
 
-refreshCache(provider);
+await refreshCache(provider);

--- a/src/common/refreshCache.ts
+++ b/src/common/refreshCache.ts
@@ -1,4 +1,4 @@
-import {
+﻿import {
   GovernanceV3Ethereum,
   GovernanceV3Arbitrum,
   GovernanceV3Avalanche,
@@ -24,27 +24,29 @@ export async function refreshCache(adapter: GovernanceCacheAdapterWithSync) {
     governance: GovernanceV3Ethereum.GOVERNANCE,
   });
 
-  [
-    GovernanceV3Ethereum,
-    GovernanceV3Arbitrum,
-    GovernanceV3Avalanche,
-    GovernanceV3Metis,
-    GovernanceV3Optimism,
-    GovernanceV3Gnosis,
-    GovernanceV3BNB,
-    GovernanceV3Polygon,
-    GovernanceV3Scroll,
-    GovernanceV3Base,
-    GovernanceV3ZkSync,
-    GovernanceV3Linea,
-    GovernanceV3Sonic,
-    GovernanceV3Celo,
-    GovernanceV3Mantle,
-    GovernanceV3Soneium,
-  ].map(({PAYLOADS_CONTROLLER, CHAIN_ID}) => {
-    return adapter.syncPayloadsCache({
-      chainId: CHAIN_ID,
-      payloadsController: PAYLOADS_CONTROLLER,
-    });
-  });
+  await Promise.all(
+    [
+      GovernanceV3Ethereum,
+      GovernanceV3Arbitrum,
+      GovernanceV3Avalanche,
+      GovernanceV3Metis,
+      GovernanceV3Optimism,
+      GovernanceV3Gnosis,
+      GovernanceV3BNB,
+      GovernanceV3Polygon,
+      GovernanceV3Scroll,
+      GovernanceV3Base,
+      GovernanceV3ZkSync,
+      GovernanceV3Linea,
+      GovernanceV3Sonic,
+      GovernanceV3Celo,
+      GovernanceV3Mantle,
+      GovernanceV3Soneium,
+    ].map(({PAYLOADS_CONTROLLER, CHAIN_ID}) => {
+      return adapter.syncPayloadsCache({
+        chainId: CHAIN_ID,
+        payloadsController: PAYLOADS_CONTROLLER,
+      });
+    }),
+  );
 }


### PR DESCRIPTION
﻿## Summary

`refreshCache` called `syncPayloadsCache` inside `.map()` but did not await the returned promises, so the function could return after proposal sync while payload syncs were still in flight.

The `scripts/refreshCache.ts` entrypoint also called `refreshCache(provider)` without `await`, so the Bun process could exit before cache refresh finished.

This change wraps the payload sync calls in `await Promise.all(...)` and uses top-level `await` in the script so all work completes before shutdown.

made by mooncitydev
